### PR TITLE
Use https as submodule url of google/docsy.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/themes/docsy"]
 	path = docs/themes/docsy
-	url = git@github.com:google/docsy.git
+	url = https://github.com/google/docsy.git


### PR DESCRIPTION
The https version can be used without registering an SSH key with GitHub.

I stumbled upon this while checking out the django-DefectDojo repository using ansible builtin git. It automatically tries to download the registered submodules. But because of the missing SSH key, the clone fails.

My reasoning for this proposed change:

- docsy is a public repo, using https should just work
- there's no real reason to use SSH, if you want to contribute to google/docsy.git you can still setup an environment with SSH
- if you don't have an SSH key registered with GitHub or you are in an environment where you don't have the key, using the submodule will fail